### PR TITLE
Resolves #66 and #68 from jerelmiller/redux-simple-auth library

### DIFF
--- a/README.md
+++ b/README.md
@@ -632,9 +632,17 @@ arguments: the session data, and a callback function.
 
 ```javascript
 
-const bearerAuthorizer = (data, block) => {
+const bearerAuthorizer = (data, headers, options, url) => {
   if (data.token) {
-    block('Authorization', `Bearer ${data.token}`)
+    headers('Authorization', `Bearer ${data.token}`)
+  }
+  // Or perhaps ...
+  if (data.usingCookieAuth) {
+    options('credentials', `same-origin`)
+  }
+  // Or perhaps ...
+  if (data.url !== '/my-unprotected-api') {
+    headers('Authorization', `Bearer ${data.token}`)
   }
 }
 
@@ -647,9 +655,15 @@ const authMiddleware = createAuthMiddleware({
 
 * `data` (_object_): The session data
 
-* `block` (_function_): A callback function responsible for defining any headers
+* `headers` (_function_): A callback function responsible for defining any headers
   needed for authorization. It accepts a header name for its first argument and
   that header's value as its second argument.
+
+* `options` (_function_): A callback function responsible for defining any fetch options
+  needed for authorization. It accepts a option name for its first argument and
+  that option's value as its second argument.
+
+* `url` (_string_): The target url for the fetch.
 
 ### Store Enhancer
 

--- a/packages/redux-simple-auth/src/middleware.js
+++ b/packages/redux-simple-auth/src/middleware.js
@@ -137,8 +137,10 @@ export default (config = {}) => {
 
           if (authorize) {
             authorize(getSessionData(state), (name, value) => {
-              headers[name] = value
-            })
+                headers[name] = value
+              }, (name, value) => {
+                options[name] = value
+              }, url)
           }
 
           return fetch(url, { ...options, headers }).then(response => {

--- a/packages/redux-simple-auth/test/middleware.spec.js
+++ b/packages/redux-simple-auth/test/middleware.spec.js
@@ -401,15 +401,15 @@ describe('FETCH dispatched', () => {
 
     store.dispatch(fetchAction('https://test.com'))
 
-    expect(authorize).toHaveBeenCalledWith(data, expect.any(Function))
+    expect(authorize).toHaveBeenCalledWith(data, expect.any(Function), expect.any(Function), 'https://test.com')
   })
 
   it('sets headers defined in authorize function', () => {
     fetch.mockResponse(JSON.stringify({ ok: true }))
     const middleware = createAuthMiddleware({
       storage,
-      authorize: (data, block) => {
-        block('Authorization', data.token)
+      authorize: (data, headers) => {
+        headers('Authorization', data.token)
       },
       authenticator: testAuthenticator
     })
@@ -422,6 +422,28 @@ describe('FETCH dispatched', () => {
 
     expect(fetch).toHaveBeenCalledWith('https://test.com', {
       headers: { Authorization: '1235' }
+    })
+  })
+
+  it('sets options defined in authorize function', () => {
+    fetch.mockResponse(JSON.stringify({ ok: true }))
+    const middleware = createAuthMiddleware({
+      storage,
+      authorize: (data, headers, options) => {
+        options('credentials', 'same-origin')
+      },
+      authenticator: testAuthenticator
+    })
+    const store = createStore({
+      middleware,
+      initialState: sessionState({ data: { token: '1235' } })
+    })
+
+    store.dispatch(fetchAction('https://test.com'))
+
+    expect(fetch).toHaveBeenCalledWith('https://test.com', {
+      credentials: 'same-origin',
+      headers: {}
     })
   })
 


### PR DESCRIPTION
- Add callback to authorizer which allows fetch options to be added to fetch call
- Authorizer receives fetch URL so it can reason on the endpoint
- Unit tests added

This commit allows implementors get more control on the fetch function. It allows allows implementors to decide which fetch calls require authorization data as the URL can be inspected.